### PR TITLE
refactoring some Guava ListenableFUture to Java 8 CompletableFuture

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,9 +43,9 @@
         <mockito.version>1.8.5</mockito.version>
 
         <!-- java version -->
-        <maven.compiler.compilerVersion>1.7</maven.compiler.compilerVersion>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.compilerVersion>1.8</maven.compiler.compilerVersion>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.executable>javac</maven.compiler.executable>
 
         <!-- build properties -->
@@ -148,8 +148,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/shellplugin/wm.x11.impl/src/main/java/org/trinity/shellplugin/wm/x11/impl/protocol/icccm/WmHints.java
+++ b/shellplugin/wm.x11.impl/src/main/java/org/trinity/shellplugin/wm/x11/impl/protocol/icccm/WmHints.java
@@ -25,6 +25,7 @@ import static org.freedesktop.xcb.LibXcb.xcb_icccm_get_wm_hints;
 import static org.freedesktop.xcb.LibXcb.xcb_icccm_get_wm_hints_reply;
 
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.inject.Inject;
@@ -70,7 +71,7 @@ public class WmHints extends AbstractCachedProtocol<xcb_icccm_wm_hints_t> {
 	}
 
 	@Override
-	protected ListenableFuture<Optional<xcb_icccm_wm_hints_t>> queryProtocol(final DisplaySurface xWindow) {
+	protected CompletableFuture<Optional<xcb_icccm_wm_hints_t>> queryProtocol(final DisplaySurface xWindow) {
 
 		final Integer winId = (Integer) xWindow.getDisplaySurfaceHandle().getNativeHandle();
 		final xcb_get_property_cookie_t get_wm_hints_cookie = xcb_icccm_get_wm_hints(	this.xConnection
@@ -78,30 +79,27 @@ public class WmHints extends AbstractCachedProtocol<xcb_icccm_wm_hints_t> {
 																								.get(),
 																						winId.intValue());
 
-		return this.displayExecutor.submit(new Callable<Optional<xcb_icccm_wm_hints_t>>() {
-			@Override
-			public Optional<xcb_icccm_wm_hints_t> call() throws Exception {
-				final xcb_icccm_wm_hints_t hints = new xcb_icccm_wm_hints_t();
-				final xcb_generic_error_t e = new xcb_generic_error_t();
+		return CompletableFuture.supplyAsync(() -> {
+			final xcb_icccm_wm_hints_t hints = new xcb_icccm_wm_hints_t();
+			final xcb_generic_error_t e = new xcb_generic_error_t();
 
-				final short stat = xcb_icccm_get_wm_hints_reply(WmHints.this.xConnection.getConnectionReference().get(),
-																get_wm_hints_cookie,
-																hints,
-																e);
-				if (xcb_generic_error_t.getCPtr(e) != 0) {
-					final String errorString = XcbErrorUtil.toString(e);
-					LOG.error(errorString);
-					return Optional.absent();
-				}
-
-				if (stat == 0) {
-					LOG.error(	"Failed to read wm_hints reply from client={}",
-								winId);
-					return Optional.absent();
-				}
-
-				return Optional.of(hints);
+			final short stat = xcb_icccm_get_wm_hints_reply(WmHints.this.xConnection.getConnectionReference().get(),
+															get_wm_hints_cookie,
+															hints,
+															e);
+			if (xcb_generic_error_t.getCPtr(e) != 0) {
+				final String errorString = XcbErrorUtil.toString(e);
+				LOG.error(errorString);
+				return Optional.absent();
 			}
-		});
+
+			if (stat == 0) {
+				LOG.error(	"Failed to read wm_hints reply from client={}",
+							winId);
+				return Optional.absent();
+			}
+
+			return Optional.of(hints);
+		}, displayExecutor);
 	}
 }

--- a/shellplugin/wm.x11.impl/src/main/java/org/trinity/shellplugin/wm/x11/impl/protocol/icccm/WmState.java
+++ b/shellplugin/wm.x11.impl/src/main/java/org/trinity/shellplugin/wm/x11/impl/protocol/icccm/WmState.java
@@ -28,6 +28,7 @@ import static org.freedesktop.xcb.LibXcb.xcb_get_property_value;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.inject.Inject;
@@ -73,7 +74,7 @@ public class WmState extends AbstractCachedProtocol<int[]> {
 	}
 
 	@Override
-	protected ListenableFuture<Optional<int[]>> queryProtocol(final DisplaySurface xWindow) {
+	protected CompletableFuture<Optional<int[]>> queryProtocol(final DisplaySurface xWindow) {
 
 		final Integer winId = (Integer) xWindow.getDisplaySurfaceHandle().getNativeHandle();
 		final xcb_get_property_cookie_t get_wm_state_cookie = xcb_get_property(	this.xConnection
@@ -84,34 +85,30 @@ public class WmState extends AbstractCachedProtocol<int[]> {
 																				getProtocolAtomId(),
 																				0,
 																				2);
-		return this.wmExecutor.submit(new Callable<Optional<int[]>>() {
+		return CompletableFuture.supplyAsync(() -> {
+			final xcb_generic_error_t e = new xcb_generic_error_t();
+			final int[] reply = new int[2];
 
-			@Override
-			public Optional<int[]> call() {
-				final xcb_generic_error_t e = new xcb_generic_error_t();
-				final int[] reply = new int[2];
-
-				final xcb_get_property_reply_t get_wm_state_reply = xcb_get_property_reply(	WmState.this.xConnection
-																									.getConnectionReference()
-																									.get(),
-																							get_wm_state_cookie,
-																							e);
-				if (xcb_generic_error_t.getCPtr(e) != 0) {
-					final String errorString = XcbErrorUtil.toString(e);
-					LOG.error(errorString);
-					return Optional.absent();
-				}
-				if (get_wm_state_reply.getLength() == 0) {
-					return Optional.absent();
-				}
-				final ByteBuffer wm_state_property_value = xcb_get_property_value(get_wm_state_reply).order(ByteOrder
-						.nativeOrder());
-				reply[0] = wm_state_property_value.getInt();
-				reply[1] = wm_state_property_value.getInt();
-
-				return Optional.of(reply);
+			final xcb_get_property_reply_t get_wm_state_reply = xcb_get_property_reply(	WmState.this.xConnection
+																								.getConnectionReference()
+																								.get(),
+																						get_wm_state_cookie,
+																						e);
+			if (xcb_generic_error_t.getCPtr(e) != 0) {
+				final String errorString = XcbErrorUtil.toString(e);
+				LOG.error(errorString);
+				return Optional.absent();
 			}
-		});
+			if (get_wm_state_reply.getLength() == 0) {
+				return Optional.absent();
+			}
+			final ByteBuffer wm_state_property_value = xcb_get_property_value(get_wm_state_reply).order(ByteOrder
+					.nativeOrder());
+			reply[0] = wm_state_property_value.getInt();
+			reply[1] = wm_state_property_value.getInt();
+
+			return Optional.of(reply);
+		}, wmExecutor);
 	}
 
 }


### PR DESCRIPTION
Hi, I'm doing research on new concurrent constructs in Java 8. `CompletableFuture` in Java 8 has the same functionality as Guava `ListenableFuture`. But `CompletableFuture` is much nicer because it comes together with Lambda expression in Java 8, and it is monadic, which makes the code more readable and cleaner. Also, it provides more ways to compose different tasks. Therefore, using `CompletableFuture` instead of `ListenableFuture` is better for future extension and maintenance of the code.

I tried to refactoring some `ListenableFuture` instances in `trinityshell` to `CompletableFuture`, so you can see the difference. You don't have to merge this pull request. I'm just wondering your opinion on this kind of refactoring (or migrating the code from Java 7 to Java 8). Do you think the refactoring is useful? Do you have any plan to use Java 8? Thanks.